### PR TITLE
Handle dates as query arguments

### DIFF
--- a/datetype.js
+++ b/datetype.js
@@ -2,21 +2,25 @@ import { GraphQLScalarType } from 'graphql'
 import { GraphQLError } from 'graphql/error'
 import { Kind } from 'graphql/language'
 
-function coerceDate (value) {
-  if (!(value instanceof Date)) {
-    // Is this how you raise a 'field error'?
-    throw new Error('Field error: value is not an instance of Date')
-  }
-  if (isNaN(value.getTime())) {
-    throw new Error('Field error: value is an invalid Date')
-  }
-  return value.toJSON()
-}
-
 export default new GraphQLScalarType({
   name: 'DateTime',
-  serialize: coerceDate,
-  parseValue: coerceDate,
+  serialize (value) {
+    if (!(value instanceof Date)) {
+      // Is this how you raise a 'field error'?
+      throw new Error('Field error: value is not an instance of Date')
+    }
+    if (isNaN(value.getTime())) {
+      throw new Error('Field error: value is an invalid Date')
+    }
+    return value.toJSON()
+  },
+  parseValue (value) {
+    const date = new Date(value)
+    if (isNaN(date.getTime())) {
+      throw new Error('Field error: value is an invalid Date')
+    }
+    return date
+  },
   parseLiteral (ast) {
     if (ast.kind !== Kind.STRING) {
       throw new GraphQLError('Query error: Can only parse strings to dates but got a: ' + ast.kind, [ast])

--- a/test/dateTimeTypeTest.js
+++ b/test/dateTimeTypeTest.js
@@ -123,6 +123,19 @@ describe('GraphQL date type', () => {
       })
     })
 
+    it('handles dates as input in arguments', async () => {
+      let someday = '2015-07-24T10:56:42.744Z'
+      let nextDay = '2015-07-25T10:56:42.744Z'
+
+      return expect(
+        await graphql(schema, `query dateQuery($date: DateTime!) { nextDay(date: $date) }`, null, {date: someday})
+      ).to.deep.equal({
+        data: {
+          nextDay: nextDay
+        }
+      })
+    })
+
     it('does not accept alternative date formats', async () => {
       let someday = 'Fri Jul 24 2015 12:56:42 GMT+0200 (CEST)'
 


### PR DESCRIPTION
It would throw `Error: Field error: value is not an instance of Date` without this patch when giving the same date in arguments instead of interpolated in the query.
