### PR TITLE
Add graphql ^0.7.0 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/soundtrackyourbrand/graphql-custom-datetype.git"
   },
   "peerDependencies": {
-    "graphql": "^0.5.0 || ^0.6.0"
+    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0"
   },
   "devDependencies": {
     "babel": "5.8.3",


### PR DESCRIPTION
graphql-js 0.7.0 was released Aug 25 2016:
https://github.com/graphql/graphql-js/releases/tag/v0.7.0
