### PR TITLE
Fix parsing dates in input variables

### DIFF
--- a/datetype.js
+++ b/datetype.js
@@ -2,32 +2,48 @@ import { GraphQLScalarType } from 'graphql'
 import { GraphQLError } from 'graphql/error'
 import { Kind } from 'graphql/language'
 
-function coerceDate (value) {
-  if (!(value instanceof Date)) {
-    // Is this how you raise a 'field error'?
-    throw new Error('Field error: value is not an instance of Date')
+function parseDate (value) {
+  let result = new Date(value)
+  if (isNaN(result.getTime())) {
+    throw new TypeError('Invalid date: ' + value)
   }
-  if (isNaN(value.getTime())) {
-    throw new Error('Field error: value is an invalid Date')
+  if (value !== result.toJSON()) {
+    throw new TypeError('Invalid date format, only accepts: YYYY-MM-DDTHH:MM:SS.SSSZ: ' + value)
   }
-  return value.toJSON()
+  return result
 }
 
 export default new GraphQLScalarType({
   name: 'DateTime',
-  serialize: coerceDate,
-  parseValue: coerceDate,
+
+  // Serialize a date to send to the client.
+  serialize (value) {
+    if (!(value instanceof Date)) {
+      throw new TypeError('Field error: value is not an instance of Date')
+    }
+    if (isNaN(value.getTime())) {
+      throw new TypeError('Field error: value is an invalid Date')
+    }
+    return value.toJSON()
+  },
+
+  // Parse a date received as a query variable.
+  parseValue (value) {
+    if (typeof value !== 'string') {
+      throw new TypeError('Field error: value is not an instance of string')
+    }
+    return parseDate(value)
+  },
+
+  // Parse a date received as an inline value.
   parseLiteral (ast) {
     if (ast.kind !== Kind.STRING) {
       throw new GraphQLError('Query error: Can only parse strings to dates but got a: ' + ast.kind, [ast])
     }
-    let result = new Date(ast.value)
-    if (isNaN(result.getTime())) {
-      throw new GraphQLError('Query error: Invalid date', [ast])
+    try {
+      return parseDate(ast.value)
+    } catch (e) {
+      throw new GraphQLError('Query error: ' + e.message, [ast])
     }
-    if (ast.value !== result.toJSON()) {
-      throw new GraphQLError('Query error: Invalid date format, only accepts: YYYY-MM-DDTHH:MM:SS.SSSZ', [ast])
-    }
-    return result
   }
 })


### PR DESCRIPTION
Input variables are data that are sent separately from the query/mutation and referenced in the query/mutation. Incoming variables are parsed using parseValue as opposed to incoming inline literals, which use parseLiteral. parseValue used coerceDate, which should only be used for outgoing dates (see this discussion: https://github.com/graphql/graphql-js/issues/500)

I have added an implementation for parseValue and some tests to demonstrate its use.